### PR TITLE
feat(ui): add reusable button component

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,24 +1,39 @@
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "primary" | "secondary" | "outline";
-  size?: "sm" | "md" | "lg";
+  variant?: "primary" | "secondary";
+  size?: "sm" | "md" | "auto";
+  type?: "button" | "submit";
+  onClick?: () => void;
+  disabled?: boolean;
 }
 
-export default function Button({ variant = "primary", size = "sm", className, ...props }: ButtonProps) {
-  const baseStyles = "rounded-[8px] cursor-pointer text-[14px] transition duration-300";
+export default function Button({ 
+  variant = "primary", 
+  size = "sm", className, 
+  type = "button",
+  onClick,
+  disabled = false,
+  
+  
+  ...props }: ButtonProps) {
+  const baseStyles = "rounded-[10px] border-[1px] text-[14px] transition focus:ring-4 focus:ring-[#F0AB59] duration-300 " ;
   const variantStyles = {
-    primary: "bg-[#FD8240] text-white hover:bg-[#EC7230]",
-    secondary: "bg-[transparent]  text-[#FD8240] hover:text-white hover:bg-[#EC7230]",
-    outline: "border border-[#FD8240] text-[#FD8240] hover:bg-[#FD8240] hover:text-white",
+    primary: `bg-[#FD8240] text-white hover:bg-[#F55D3E] border-[transparent] cursor-pointer ${disabled ? "bg-[gray] text-[gray] opacity-50 hover:bg-[gray] cursor-not-allowed": ""}`,
+    secondary: `bg-[transparent]  border-[#FD8240] text-[#FD8240] hover:text-[#F55D3E] hover:border-[#F55D3E]  cursor-pointer ${disabled ? "border-[gray] hover:border-[gray] text-[gray] cursor-not-allowed opacity-50 hover:text-[gray] ": ""}`,
+    
   };
   const sizeStyles = {
-    sm: "w-[155px] h-[56px]",
+    sm: "w-full md:w-[109px] h-[40px]",
     md: "px-[44px] py-[44px]",
-    lg: "px-6 py-3",
+    auto: "w-full h-[56px]",
   };
+ 
 
   return (
     <button
+      type={type}
+      disabled = {disabled}
+      onClick={onClick}
       className={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
       {...props}
     />


### PR DESCRIPTION
Added reusable primary/secondary button component with hover, focus, and disabled states with variable sizes.